### PR TITLE
Update rocketpyalpha to rocketpy!

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-rocketpyalpha==0.9.6
+rocketpy==0.9.6
 numpy >= 1.0
 scipy >= 1.0
 matplotlib >= 3.0


### PR DESCRIPTION
RocketPy is out of alpha and should now be installed by `pip install rocketpy`. The `rocketpyalpha` packaged will be deprecated and removed from PyPI by the end of 2021.

Note that you can still install `rocketpyalpha==0.9.6` by using instead `rocketpy==0.9.6`.

Your project seems awesome! In fact, we would be glad to have you be a part of the RocketPy team! Let us know if you are interested.